### PR TITLE
[Feat] #33 video encode

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,6 +116,9 @@ dependencies {
     implementation "androidx.camera:camera-view:${camerax_version}"
     implementation "androidx.camera:camera-extensions:${camerax_version}"
 
+    // Video Encode - Bravobit FFmped-Android
+    implementation "nl.bravobit:android-ffmpeg:$bravoBit_version"
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     implementation "androidx.camera:camera-extensions:${camerax_version}"
 
     // Video Encode - Bravobit FFmped-Android
-    implementation "nl.bravobit:android-ffmpeg:$bravoBit_version"
+    implementation "com.arthenica:mobile-ffmpeg-full:${ffmpeg_version}"
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/main/java/com/example/fit4you_android/ui/view/basicstatuscheck/posetest/UserRomFragment.kt
+++ b/app/src/main/java/com/example/fit4you_android/ui/view/basicstatuscheck/posetest/UserRomFragment.kt
@@ -188,8 +188,8 @@ class UserRomFragment : BaseFragment<FragmentUserRomBinding, UserRomViewModel>()
                 // 아래는 필요한 Quality.HIGEST가 이미지 캡쳐에서 지원되지 않는 경우 CameraX가 지원되는 해상도 선택 가능
                 .setQualitySelector(
                     QualitySelector.from(
-                        Quality.HIGHEST,
-                        FallbackStrategy.higherQualityOrLowerThan(Quality.SD)
+                        Quality.SD,
+                        FallbackStrategy.lowerQualityThan(Quality.SD)
                     )
                 )
                 .build()

--- a/app/src/main/java/com/example/fit4you_android/ui/view/basicstatuscheck/posetest/UserRomFragment.kt
+++ b/app/src/main/java/com/example/fit4you_android/ui/view/basicstatuscheck/posetest/UserRomFragment.kt
@@ -182,10 +182,6 @@ class UserRomFragment : BaseFragment<FragmentUserRomBinding, UserRomViewModel>()
                 }
             // 비디오 캡쳐를 위한 Recorder를 설정
             val recorder = Recorder.Builder()
-                // 아래와 같이 사용하면 비디오 사용 사례가 추가됨.
-//                .setQualitySelector(QualitySelector.from(Quality.HIGHEST))
-//                .build()
-                // 아래는 필요한 Quality.HIGEST가 이미지 캡쳐에서 지원되지 않는 경우 CameraX가 지원되는 해상도 선택 가능
                 .setQualitySelector(
                     QualitySelector.from(
                         Quality.SD,

--- a/app/src/main/res/layout/fragment_user_rom.xml
+++ b/app/src/main/res/layout/fragment_user_rom.xml
@@ -14,8 +14,12 @@
 
             <androidx.camera.view.PreviewView
                 android:id="@+id/viewFinder"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"/>
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/video_capture_button"

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
         retrofit_version = '2.9.0'
         kotlin_version = '1.8.0'
         camerax_version = '1.3.0-alpha06'
+        bravoBit_version = '1.1.7'
     }
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         retrofit_version = '2.9.0'
         kotlin_version = '1.8.0'
         camerax_version = '1.3.0-alpha06'
-        bravoBit_version = '1.1.7'
+        ffmpeg_version = '4.4'
     }
     repositories {
         google()


### PR DESCRIPTION
## Video Encode
- AI 모델에 맞게 클라이언트에서 녹화한 영상을 인코딩해서 서버에 전송하려 했지만 시간관계상 간단하게 화질만 맞춤
- SD 화질로 녹화하고 기기가 SD화질로도 녹화할 여건이 안되면 SD 화질 이하로 녹화
- 인코딩하는 mobile ffmpeg 라이브러리를 추가했지만 사용하지는 않음.
- 동영상 녹화 후 저장하는 기능까지 구현

## TODO
- 녹화한 영상을 서버에 보낼 수 있게 사전준비